### PR TITLE
Add standalone GrpcClient with simple API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,83 @@ The package provides the following parts of the API:
 Add the `\Spiral\Grpc\Client\Bridge\GrpcClientBootloader` bootloader to the list of bootloaders
 in the application configuration (usually it is `Kernel.php`).
 
+#### Standalone Usage
+
+The `GrpcClient` class provides a lightweight, Guzzle-like API for making gRPC calls
+without any framework or DI container:
+
+```php
+use Spiral\Grpc\Client\GrpcClient;
+
+// Minimal — one endpoint, call service methods right away
+$client = GrpcClient::create('localhost:9001');
+$mailSender = $client->service(\GRPC\MyService\MailSenderInterface::class);
+$mailSender->sendMail($ctx, $request);
+```
+
+Add interceptors using the convenient `createConfig()` factories:
+
+```php
+use Spiral\Grpc\Client\GrpcClient;
+use Spiral\Grpc\Client\Interceptor\SetTimeoutInterceptor;
+use Spiral\Grpc\Client\Interceptor\RetryInterceptor;
+
+$client = GrpcClient::create('localhost:9001')
+    ->withInterceptors([
+        SetTimeoutInterceptor::createConfig(10_000),
+        RetryInterceptor::createConfig(maximumAttempts: 3),
+    ]);
+```
+
+Multiple connections for failover:
+
+```php
+$client = GrpcClient::create(['localhost:9001', 'localhost:9002']);
+```
+
+`ConnectionConfig` for TLS:
+
+```php
+use Spiral\Grpc\Client\Config\ConnectionConfig;
+use Spiral\Grpc\Client\Config\TlsConfig;
+
+$client = GrpcClient::create(
+    new ConnectionConfig('localhost:9001', tls: new TlsConfig(
+        certChain: '/my-project.pem',
+        privateKey: '/my-project.key',
+    )),
+);
+```
+
+With a factory (e.g. Spiral's container) to resolve class-string interceptors via DI:
+
+```php
+$client = GrpcClient::create('localhost:9001')
+    ->withFactory($factory);
+```
+
+The `with*` methods are immutable — each returns a new instance, so you can safely
+derive pre-configured clients:
+
+```php
+$base = GrpcClient::create('localhost:9001')
+    ->withInterceptors([SetTimeoutInterceptor::createConfig(5_000)]);
+
+$withRetry = $base->withInterceptors([
+    SetTimeoutInterceptor::createConfig(5_000),
+    RetryInterceptor::createConfig(maximumAttempts: 3),
+]);
+```
+
+> [!NOTE]
+> `GrpcClient` does not support per-service interceptors. If you need that,
+> use `ServiceClientProvider` with the full `GrpcClientConfig` / `ExecuteServiceInterceptors` setup.
+
 #### Other Frameworks
 
-If you are using this package outside the [Spiral](https://spiral.dev/) framework,
-you need to figure out how to use the `\Spiral\Grpc\Client\ServiceClientProvider` provider
-to get ready-to-use gRPC clients.
+If you are using this package with another framework,
+you can use `\Spiral\Grpc\Client\ServiceClientProvider` with a `GrpcClientConfig`
+to get ready-to-use gRPC clients, or use the standalone `GrpcClient` described above.
 
 ### Configuration DTOs
 
@@ -52,13 +124,13 @@ Now let's consider a configuration example:
 use Spiral\Grpc\Client\Config\GrpcClientConfig;
 use Spiral\Grpc\Client\Config\ServiceConfig;
 use Spiral\Grpc\Client\Config\ConnectionConfig;
-use Spiral\Grpc\Client\Interceptor\SetTimoutInterceptor;
+use Spiral\Grpc\Client\Interceptor\SetTimeoutInterceptor;
 use Spiral\Grpc\Client\Interceptor\RetryInterceptor;
 use Spiral\Grpc\Client\Interceptor\ExecuteServiceInterceptors;
 
 new GrpcClientConfig(
     interceptors: [
-        SetTimoutInterceptor::createConfig(10_000), // 10 seconds
+        SetTimeoutInterceptor::createConfig(10_000), // 10 seconds
         RetryInterceptor::createConfig(
             maximumAttempts: 3,
             initialInterval: 100, // 0.1 seconds

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "psr/container": "^2.0",
         "spiral/core": "^3.14",
         "spiral/hmvc": "^3.14",
-        "spiral/tokenizer": "^3.13"
+        "spiral/tokenizer": "^3.13",
+        "symfony/polyfill-php82": "*"
     },
     "require-dev": {
         "buggregator/trap": "^1.11.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd64aaeb95a361ff1aff0c9137572bde",
+    "content-hash": "49b3bcb11ae8e2290ffef0174757dd07",
     "packages": [
         {
             "name": "google/common-protos",
@@ -818,6 +818,86 @@
                 }
             ],
             "time": "2026-01-29T09:40:50+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php82",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php82.git",
+                "reference": "5d2ed36f7734637dacc025f179698031951b1692"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/5d2ed36f7734637dacc025f179698031951b1692",
+                "reference": "5d2ed36f7734637dacc025f179698031951b1692",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php82\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php82/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
         }
     ],
     "packages-dev": [
@@ -3941,28 +4021,29 @@
         },
         {
             "name": "roxblnfk/unpoly",
-            "version": "1.8.2",
+            "version": "1.8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roxblnfk/unpoly.git",
-                "reference": "680f8ed460513935aa896391402afe0e4660c3bf"
+                "reference": "ec84dc56c97320acde5ab8875a39de36fdce36a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roxblnfk/unpoly/zipball/680f8ed460513935aa896391402afe0e4660c3bf",
-                "reference": "680f8ed460513935aa896391402afe0e4660c3bf",
+                "url": "https://api.github.com/repos/roxblnfk/unpoly/zipball/ec84dc56c97320acde5ab8875a39de36fdce36a9",
+                "reference": "ec84dc56c97320acde5ab8875a39de36fdce36a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.1"
             },
             "replace": {
+                "symfony/polyfill-php70": "*",
+                "symfony/polyfill-php71": "*",
                 "symfony/polyfill-php72": "*",
                 "symfony/polyfill-php73": "*",
                 "symfony/polyfill-php74": "*",
                 "symfony/polyfill-php80": "*",
-                "symfony/polyfill-php81": "*",
-                "symfony/polyfill-php82": "*"
+                "symfony/polyfill-php81": "*"
             },
             "type": "metapackage",
             "notification-url": "https://packagist.org/downloads/",
@@ -3984,7 +4065,7 @@
             ],
             "support": {
                 "issues": "https://github.com/roxblnfk/unpoly/issues",
-                "source": "https://github.com/roxblnfk/unpoly/tree/1.8.2"
+                "source": "https://github.com/roxblnfk/unpoly/tree/1.8.1.1"
             },
             "funding": [
                 {
@@ -3992,7 +4073,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2024-02-06T20:28:31+00:00"
+            "time": "2024-02-06T20:26:09+00:00"
         },
         {
             "name": "sebastian/diff",

--- a/composer.lock
+++ b/composer.lock
@@ -3219,16 +3219,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "6.0.2",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "897b5986ece6b4f9d8413fea345c7d49c757d6bf"
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/897b5986ece6b4f9d8413fea345c7d49c757d6bf",
-                "reference": "897b5986ece6b4f9d8413fea345c7d49c757d6bf",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
                 "shasum": ""
             },
             "require": {
@@ -3278,9 +3278,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.2"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
             },
-            "time": "2026-03-01T18:43:49+00:00"
+            "time": "2026-03-18T20:49:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -5952,16 +5952,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.16.0",
+            "version": "6.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "7cf3e8b988edd75e0766963b0b9e671b220f5785"
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/7cf3e8b988edd75e0766963b0b9e671b220f5785",
-                "reference": "7cf3e8b988edd75e0766963b0b9e671b220f5785",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
                 "shasum": ""
             },
             "require": {
@@ -6066,7 +6066,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2026-03-17T11:15:56+00:00"
+            "time": "2026-03-19T10:56:09+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Bridge/GrpcClientBootloader.php
+++ b/src/Bridge/GrpcClientBootloader.php
@@ -8,7 +8,7 @@ use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Core\BinderInterface;
 use Spiral\Grpc\Client\ServiceClientProvider;
 
-class GrpcClientBootloader extends Bootloader
+final class GrpcClientBootloader extends Bootloader
 {
     public function boot(BinderInterface $binder): void
     {

--- a/src/Exception/ServiceClientException.php
+++ b/src/Exception/ServiceClientException.php
@@ -8,7 +8,7 @@ use Google\Protobuf\Any;
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Rpc\Status;
 
-class ServiceClientException extends \RuntimeException implements GrpcClientException
+final class ServiceClientException extends \RuntimeException implements GrpcClientException
 {
     private Status $status;
 

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 namespace Spiral\Grpc\Client\Exception;
 
-class TimeoutException extends \RuntimeException implements GrpcClientException {}
+final class TimeoutException extends \RuntimeException implements GrpcClientException {}

--- a/src/GrpcClient.php
+++ b/src/GrpcClient.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Grpc\Client;
+
+use Spiral\Core\Container;
+use Spiral\Core\Container\Autowire;
+use Spiral\Core\FactoryInterface;
+use Spiral\Grpc\Client\Config\ConnectionConfig;
+use Spiral\Grpc\Client\Config\ServiceConfig;
+use Spiral\Grpc\Client\Internal\Registry\ServiceRegistry;
+use Spiral\Grpc\Client\Internal\ServiceClient\ClientFactory;
+use Spiral\Interceptors\Handler\CallableHandler;
+use Spiral\Interceptors\HandlerInterface;
+use Spiral\Interceptors\InterceptorInterface;
+use Spiral\Interceptors\PipelineBuilder;
+use Spiral\Interceptors\PipelineBuilderInterface;
+
+/**
+ * Standalone gRPC client that doesn't require a DI container or framework integration.
+ *
+ * One instance represents a single set of endpoints. Use {@see self::service()} to obtain
+ * typed service clients and {@see self::withInterceptors()} to configure the interceptor pipeline.
+ *
+ * For per-service interceptors or full framework integration,
+ * use {@see ServiceClientProvider} with {@see Config\GrpcClientConfig} instead.
+ */
+final class GrpcClient
+{
+    /** @var list<ConnectionConfig> */
+    private readonly array $connections;
+
+    /** @var list<InterceptorInterface|class-string<InterceptorInterface>|Autowire> */
+    private array $interceptors = [];
+
+    private ?FactoryInterface $factory = null;
+    private PipelineBuilderInterface $pipelineBuilder;
+    private ?ServiceRegistry $registry = null;
+    private ?ClientFactory $clientFactory = null;
+    private ?HandlerInterface $handler = null;
+
+    /** @var array<class-string, object> */
+    private array $serviceCache = [];
+
+    /**
+     * @param list<ConnectionConfig> $connections
+     */
+    private function __construct(array $connections)
+    {
+        $this->connections = $connections;
+        $this->pipelineBuilder = new PipelineBuilder();
+    }
+
+    /**
+     * Create a new gRPC client for the given endpoint(s).
+     *
+     * @param non-empty-string|ConnectionConfig|list<non-empty-string|ConnectionConfig> $endpoints
+     *        At least one endpoint is required. Strings are auto-wrapped in {@see ConnectionConfig}.
+     */
+    public static function create(string|ConnectionConfig|array $endpoints): self
+    {
+        $endpoints = \is_array($endpoints) ? $endpoints : [$endpoints];
+        $endpoints === [] and throw new \InvalidArgumentException(
+            'At least one endpoint is required.',
+        );
+
+        $connections = [];
+        foreach ($endpoints as $endpoint) {
+            $connections[] = \is_string($endpoint)
+                ? new ConnectionConfig($endpoint)
+                : $endpoint;
+        }
+
+        return new self($connections);
+    }
+
+    /**
+     * Return a new instance with the given interceptors (replaces, not appends).
+     *
+     * @param list<InterceptorInterface|class-string<InterceptorInterface>|Autowire> $interceptors
+     */
+    public function withInterceptors(array $interceptors): self
+    {
+        $clone = clone $this;
+        $clone->interceptors = $interceptors;
+        $clone->resetLazyState();
+        return $clone;
+    }
+
+    /**
+     * Return a new instance with the given factory for DI-based interceptor resolution.
+     */
+    public function withFactory(FactoryInterface $factory): self
+    {
+        $clone = clone $this;
+        $clone->factory = $factory;
+        $clone->resetLazyState();
+        return $clone;
+    }
+
+    /**
+     * Return a new instance with the given pipeline builder.
+     */
+    public function withPipelineBuilder(PipelineBuilderInterface $pipelineBuilder): self
+    {
+        $clone = clone $this;
+        $clone->pipelineBuilder = $pipelineBuilder;
+        $clone->resetLazyState();
+        return $clone;
+    }
+
+    /**
+     * Get a typed gRPC service client for the given interface.
+     *
+     * @template T
+     * @param class-string<T> $interface
+     * @return T
+     */
+    public function service(string $interface): object
+    {
+        if (isset($this->serviceCache[$interface])) {
+            /** @var T */
+            return $this->serviceCache[$interface];
+        }
+
+        $this->registry ??= new ServiceRegistry();
+        $this->clientFactory ??= new ClientFactory($this->registry);
+
+        $this->registry->addServices(new ServiceConfig(
+            connections: $this->connections,
+            interfaces: [$interface],
+        ));
+
+        $this->handler ??= $this->buildHandler();
+
+        $client = $this->clientFactory->make($interface, $this->handler);
+        $this->serviceCache[$interface] = $client;
+
+        /** @var T */
+        return $client;
+    }
+
+    private function buildHandler(): HandlerInterface
+    {
+        $factory = $this->factory ??= new Container();
+
+        $resolved = [];
+        foreach ($this->interceptors as $interceptor) {
+            $resolved[] = $this->resolveInterceptor($interceptor, $factory);
+        }
+
+        return $this->pipelineBuilder
+            ->withInterceptors(...$resolved)
+            ->build(new CallableHandler());
+    }
+
+    /**
+     * @param InterceptorInterface|class-string<InterceptorInterface>|Autowire $interceptor
+     */
+    private function resolveInterceptor(
+        InterceptorInterface|string|Autowire $interceptor,
+        FactoryInterface $factory,
+    ): InterceptorInterface {
+        if ($interceptor instanceof InterceptorInterface) {
+            return $interceptor;
+        }
+
+        if ($interceptor instanceof Autowire) {
+            /** @var InterceptorInterface */
+            return $interceptor->resolve($factory);
+        }
+
+        /** @var InterceptorInterface */
+        return $factory->make($interceptor);
+    }
+
+    private function resetLazyState(): void
+    {
+        $this->registry = null;
+        $this->clientFactory = null;
+        $this->handler = null;
+        $this->serviceCache = [];
+    }
+}

--- a/src/Interceptor/ConnectionsRotationInterceptor.php
+++ b/src/Interceptor/ConnectionsRotationInterceptor.php
@@ -16,6 +16,7 @@ use Spiral\Interceptors\InterceptorInterface;
  */
 final class ConnectionsRotationInterceptor implements InterceptorInterface
 {
+    #[\Override]
     public function intercept(CallContextInterface $context, HandlerInterface $handler): mixed
     {
         $connections = Helper::getConnections($context);

--- a/src/Interceptor/ExecuteServiceInterceptors.php
+++ b/src/Interceptor/ExecuteServiceInterceptors.php
@@ -24,6 +24,7 @@ final class ExecuteServiceInterceptors implements Interceptor
         private readonly PipelineBuilderInterface $pipelineBuilder,
     ) {}
 
+    #[\Override]
     public function intercept(CallContextInterface $context, HandlerInterface $handler): mixed
     {
         // Get current connection

--- a/src/Interceptor/RetryInterceptor.php
+++ b/src/Interceptor/RetryInterceptor.php
@@ -70,6 +70,7 @@ final class RetryInterceptor implements InterceptorInterface
             ->toAutowire();
     }
 
+    #[\Override]
     public function intercept(CallContextInterface $context, HandlerInterface $handler): mixed
     {
         $attempt = 0;
@@ -80,7 +81,7 @@ final class RetryInterceptor implements InterceptorInterface
         // Use deadline if timeout was defined before the interceptor
         $timeout = Helper::getOptions($context)['timeout'] ?? null;
         // Deadline in unix timestamp with microseconds
-        $deadline = \is_int($timeout) ? \microtime(true) + $timeout / 1_000_000 : null;
+        $deadline = \is_int($timeout) ? \microtime(true) + (float) $timeout / 1_000_000.0 : null;
 
         do_try:
         ++$attempt;
@@ -127,7 +128,7 @@ final class RetryInterceptor implements InterceptorInterface
             );
 
             // The next retry must be started before the deadline
-            $deadline === null || \microtime(true) + $wait / 1000 < $deadline or throw new TimeoutException(
+            $deadline === null || \microtime(true) + (float) $wait / 1000.0 < $deadline or throw new TimeoutException(
                 "Deadline exceeded after $attempt attempts.",
                 StatusCode::DeadlineExceeded->value,
             );

--- a/src/Interceptor/RetryInterceptor.php
+++ b/src/Interceptor/RetryInterceptor.php
@@ -18,7 +18,7 @@ use Spiral\Interceptors\InterceptorInterface;
  * Apply retry logic to the gRPC call.
  *
  * If the timeout is defined in the context before the interceptor, it will be used as a deadline between retries.
- * To set the timeout, use {@see SetTimoutInterceptor}.
+ * To set the timeout, use {@see SetTimeoutInterceptor}.
  *
  * Use {@see RetryInterceptor::createConfig()} to create a config DTO in a configuration file.
  */

--- a/src/Interceptor/SetTimeoutInterceptor.php
+++ b/src/Interceptor/SetTimeoutInterceptor.php
@@ -14,7 +14,7 @@ use Spiral\Interceptors\InterceptorInterface;
  *
  * Use {@see RetryInterceptor::createConfig()} to create a config DTO in a configuration file.
  */
-final class SetTimoutInterceptor implements InterceptorInterface
+final class SetTimeoutInterceptor implements InterceptorInterface
 {
     /**
      * @param int<1, max>|null $timeout Timeout in milliseconds.

--- a/src/Interceptor/SetTimeoutInterceptor.php
+++ b/src/Interceptor/SetTimeoutInterceptor.php
@@ -41,6 +41,7 @@ final class SetTimeoutInterceptor implements InterceptorInterface
         return new Autowire(self::class, [$timeout]);
     }
 
+    #[\Override]
     public function intercept(CallContextInterface $context, HandlerInterface $handler): mixed
     {
         $options = Helper::getOptions($context);

--- a/src/Internal/Connection/ClientStub.php
+++ b/src/Internal/Connection/ClientStub.php
@@ -12,7 +12,7 @@ use Spiral\Grpc\Client\Internal\StatusCode;
 /**
  * @internal
  */
-class ClientStub extends BaseStub
+final class ClientStub extends BaseStub
 {
     public function invoke(
         string $method,

--- a/src/Internal/Connection/Connection.php
+++ b/src/Internal/Connection/Connection.php
@@ -25,17 +25,20 @@ final class Connection implements ConnectionInterface
         $this->initClient();
     }
 
+    #[\Override]
     public function getStub(): ClientStub
     {
         $this->initClient();
         return $this->stub;
     }
 
+    #[\Override]
     public function isConnected(): bool
     {
         return ConnectionState::from($this->stub->getConnectivityState(false)) === ConnectionState::Ready;
     }
 
+    #[\Override]
     public function connect(float $timeout): void
     {
         $deadline = \microtime(true) + $timeout;
@@ -75,6 +78,7 @@ final class Connection implements ConnectionInterface
         );
     }
 
+    #[\Override]
     public function disconnect(): void
     {
         if ($this->closed) {

--- a/tests/Acceptance/GrpcClientTest.php
+++ b/tests/Acceptance/GrpcClientTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Grpc\Client\Tests\Acceptance;
+
+use Spiral\Grpc\Client\Exception\ServiceClientException;
+use Spiral\Grpc\Client\GrpcClient;
+use Spiral\Grpc\Client\Interceptor\ConnectionsRotationInterceptor;
+use Spiral\Grpc\Client\Interceptor\RetryInterceptor;
+use Spiral\Grpc\Client\Interceptor\SetTimeoutInterceptor;
+use Spiral\Grpc\Client\Tests\Generated\Grpcbin\DummyMessage;
+use Spiral\Grpc\Client\Tests\Generated\Grpcbin\EmptyMessage;
+use Spiral\Grpc\Client\Tests\Generated\Grpcbin\GRPCBinInterface;
+use Spiral\Grpc\Client\Tests\Generated\Grpcbin\SpecificErrorRequest;
+use Testo\Assert;
+use Testo\Expect;
+use Testo\Test;
+
+#[Test]
+final class GrpcClientTest
+{
+    private const GRPCBIN_ADDRESS = '127.0.0.1:9000';
+
+    public function basicUnaryCall(): void
+    {
+        $client = GrpcClient::create(self::GRPCBIN_ADDRESS);
+        $service = $client->service(GRPCBinInterface::class);
+        $ctx = new GrpcContext();
+
+        $request = new DummyMessage([
+            'f_string' => 'hello standalone',
+            'f_int32' => 7,
+        ]);
+
+        $response = $service->DummyUnary($ctx, $request);
+
+        Assert::same($response->getFString(), 'hello standalone');
+        Assert::same($response->getFInt32(), 7);
+    }
+
+    public function unaryCallWithInterceptors(): void
+    {
+        $client = GrpcClient::create(self::GRPCBIN_ADDRESS)
+            ->withInterceptors([
+                SetTimeoutInterceptor::createConfig(10_000),
+                RetryInterceptor::createConfig(maximumAttempts: 3),
+            ]);
+
+        $service = $client->service(GRPCBinInterface::class);
+        $ctx = new GrpcContext();
+
+        $response = $service->Empty($ctx, new EmptyMessage());
+
+        Assert::instanceOf($response, EmptyMessage::class);
+    }
+
+    public function connectionsRotationFailover(): void
+    {
+        // First endpoint is dead, second is alive — rotation should switch to the working one
+        $client = GrpcClient::create(['127.0.0.1:19999', self::GRPCBIN_ADDRESS])
+            ->withInterceptors([
+                new ConnectionsRotationInterceptor(),
+            ]);
+
+        $service = $client->service(GRPCBinInterface::class);
+        $ctx = new GrpcContext();
+
+        $response = $service->DummyUnary($ctx, new DummyMessage([
+            'f_string' => 'rotated',
+        ]));
+
+        Assert::same($response->getFString(), 'rotated');
+    }
+
+    public function specificErrorNotFound(): void
+    {
+        $client = GrpcClient::create(self::GRPCBIN_ADDRESS);
+        $service = $client->service(GRPCBinInterface::class);
+
+        Expect::exception(ServiceClientException::class);
+
+        $service->SpecificError(new GrpcContext(), new SpecificErrorRequest([
+            'code' => 5, // NOT_FOUND
+            'reason' => 'test not found',
+        ]));
+    }
+
+    public function specificErrorPermissionDenied(): void
+    {
+        $client = GrpcClient::create(self::GRPCBIN_ADDRESS);
+        $service = $client->service(GRPCBinInterface::class);
+
+        Expect::exception(ServiceClientException::class);
+
+        $service->SpecificError(new GrpcContext(), new SpecificErrorRequest([
+            'code' => 7, // PERMISSION_DENIED
+            'reason' => 'test permission denied',
+        ]));
+    }
+}

--- a/tests/Unit/GrpcClientTest.php
+++ b/tests/Unit/GrpcClientTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Grpc\Client\Tests\Unit;
+
+use Spiral\Core\Container\Autowire;
+use Spiral\Core\FactoryInterface;
+use Spiral\Grpc\Client\Config\ConnectionConfig;
+use Spiral\Grpc\Client\GrpcClient;
+use Spiral\Interceptors\Context\CallContextInterface;
+use Spiral\Interceptors\HandlerInterface;
+use Spiral\Interceptors\InterceptorInterface;
+use Testo\Assert;
+use Testo\Expect;
+use Testo\Test;
+
+#[Test]
+final class GrpcClientTest
+{
+    public function createWithStringEndpoint(): void
+    {
+        $client = GrpcClient::create('localhost:9001');
+
+        Assert::instanceOf($client, GrpcClient::class);
+    }
+
+    public function createWithConnectionConfig(): void
+    {
+        $client = GrpcClient::create(new ConnectionConfig('localhost:9001'));
+
+        Assert::instanceOf($client, GrpcClient::class);
+    }
+
+    public function createWithArray(): void
+    {
+        $client = GrpcClient::create([
+            'localhost:9001',
+            new ConnectionConfig('localhost:9002'),
+            'localhost:9003',
+        ]);
+
+        Assert::instanceOf($client, GrpcClient::class);
+    }
+
+    public function createWithEmptyArrayThrows(): void
+    {
+        Expect::exception(\InvalidArgumentException::class);
+
+        GrpcClient::create([]);
+    }
+
+    public function withInterceptorsReturnsNewInstance(): void
+    {
+        $client = GrpcClient::create('localhost:9001');
+        $new = $client->withInterceptors([]);
+
+        Assert::notSame($client, $new);
+    }
+
+    public function withFactoryReturnsNewInstance(): void
+    {
+        $factory = new class implements FactoryInterface {
+            public function make(string $alias, array $parameters = []): mixed
+            {
+                return new $alias(...$parameters);
+            }
+        };
+
+        $client = GrpcClient::create('localhost:9001');
+        $new = $client->withFactory($factory);
+
+        Assert::notSame($client, $new);
+    }
+
+    public function serviceReturnsCachedInstance(): void
+    {
+        $client = GrpcClient::create('localhost:9001');
+        $first = $client->service(StubServiceInterface::class);
+        $second = $client->service(StubServiceInterface::class);
+
+        Assert::same($first, $second);
+    }
+
+    public function withInterceptorsInvalidatesCacheOnNewInstance(): void
+    {
+        $client = GrpcClient::create('localhost:9001');
+        $first = $client->service(StubServiceInterface::class);
+
+        $new = $client->withInterceptors([]);
+        $second = $new->service(StubServiceInterface::class);
+
+        // Original still returns the same cached instance
+        Assert::same($first, $client->service(StubServiceInterface::class));
+        // New instance has a different service object
+        Assert::notSame($first, $second);
+    }
+
+    public function autowireInterceptorResolvesWithoutFactory(): void
+    {
+        $interceptor = new Autowire(StubInterceptor::class, []);
+        $client = GrpcClient::create('localhost:9001')
+            ->withInterceptors([$interceptor]);
+
+        $service = $client->service(StubServiceInterface::class);
+
+        Assert::instanceOf($service, StubServiceInterface::class);
+    }
+
+    public function classStringInterceptorWithoutFactory(): void
+    {
+        $client = GrpcClient::create('localhost:9001')
+            ->withInterceptors([StubInterceptor::class]);
+
+        $service = $client->service(StubServiceInterface::class);
+
+        Assert::instanceOf($service, StubServiceInterface::class);
+    }
+
+    public function classStringInterceptorWithCustomFactory(): void
+    {
+        $factory = new StubFactory();
+
+        $client = GrpcClient::create('localhost:9001')
+            ->withFactory($factory)
+            ->withInterceptors([StubInterceptor::class]);
+
+        $client->service(StubServiceInterface::class);
+
+        Assert::true($factory->called);
+    }
+
+    public function noMemoryLeaksAfterUnset(): void
+    {
+        $interceptor = new StubInterceptor();
+        Expect::notLeaks($interceptor);
+
+        $client = GrpcClient::create('localhost:9001')
+            ->withInterceptors([$interceptor]);
+
+        $client->service(StubServiceInterface::class);
+
+        unset($client);
+    }
+}
+
+/**
+ * Minimal gRPC service interface for testing.
+ * @internal
+ */
+interface StubServiceInterface
+{
+    public function Ping(\Spiral\RoadRunner\GRPC\ContextInterface $ctx, \Google\Protobuf\GPBEmpty $in): \Google\Protobuf\GPBEmpty;
+}
+
+/**
+ * @internal
+ */
+final class StubInterceptor implements InterceptorInterface
+{
+    public function intercept(CallContextInterface $context, HandlerInterface $handler): mixed
+    {
+        return $handler->handle($context);
+    }
+}
+
+/**
+ * @internal
+ */
+final class StubFactory implements FactoryInterface
+{
+    public bool $called = false;
+
+    public function make(string $alias, array $parameters = []): mixed
+    {
+        $this->called = true;
+        return new $alias(...$parameters);
+    }
+}


### PR DESCRIPTION
## What was changed

Adds GrpcClient — lightweight entry point for making gRPC calls without a framework, bootloader, or pre-configured GrpcClientConfig.

```php
  $client = GrpcClient::create('localhost:9001');
  $mailSender = $client->service(MailSenderInterface::class);
```

- `create()` accepts string addresses, `ConnectionConfig, or an array for multiple endpoints
- `withInterceptors()` / `withFactory()` / `withPipelineBuilder()` — immutable configuration
- Lazily creates a `spiral/core` `Container` as default factory, so class-string and `Autowire`
interceptors work out of the box
- Service clients are cached per interface; `with*()` calls reset the cache on the new instance
- No changes to existing classes — pure composition on top of `ServiceRegistry`, `ClientFactory`, etc.

## Checklist

- Tested
    - [ ] Tested manually
    - [x] Unit tests added

